### PR TITLE
Fix padding width for multibyte characters

### DIFF
--- a/org-dashboard.el
+++ b/org-dashboard.el
@@ -195,7 +195,7 @@ See Info node `(org) Breaking down tasks'."
              do (let* ((category-label (make-category-label category))
                        (goal-label (make-goal-label goal-heading))
                        (goal-link (make-link file goal-heading goal-label))
-                       (goal-label-padding (make-string (- 25 (length goal-label)) ?\s))
+                       (goal-label-padding (make-string (- 25 (string-width goal-label)) ?\s))
                        (progress-bar (make-progress-bar percent))
                        (percent-indicator (format "%3d%%" percent)))
 


### PR DESCRIPTION
Hi.

This PR intends to fix a broken alignment when a heading includes multibyte characters.  Please see the effect below.

(the original)
![untitled](https://cloud.githubusercontent.com/assets/136673/18407375/d5811572-7749-11e6-86b2-4b4374cd98dd.png)

(proposed)
![screen shot 2016-09-10 at 11 15 02](https://cloud.githubusercontent.com/assets/136673/18407360/4de8b160-7749-11e6-828f-c742e30e239e.png)

Best,
Takaaki
